### PR TITLE
Fixed convoy route computation through ports

### DIFF
--- a/diplomacy/utils/convoy_paths.py
+++ b/diplomacy/utils/convoy_paths.py
@@ -110,7 +110,7 @@ def _get_convoy_paths(map_object, start_location, max_convoy_length, queue):
                     dest_paths[loc] += [fleets_loc]
 
             # If we find adjacent water/port, we add them to the queue
-            elif map_object.area_type(loc) in WATER_TYPES \
+            if map_object.area_type(loc) in WATER_TYPES \
                     and loc not in fleets_loc \
                     and len(fleets_loc) < max_convoy_length:
                 to_check.put((fleets_loc | {loc}, loc))


### PR DESCRIPTION
Convoys through ports currently only work if the port is the only step of the route, going start-port-destination. Ports cannot be part of longer convoy chains.

The cause is the `elif` line 113, since ports (being valid destinations of convoys) will match the condition for the `if` line 101. However, ports are both possible destinations and possible next water-like regions, so the two test should be independent `if`s.