### PR TITLE
Fixed not influencing the parent but the coast itself when retreating to a coast.

### DIFF
--- a/diplomacy/engine/game.py
+++ b/diplomacy/engine/game.py
@@ -4471,9 +4471,9 @@ class Game(Jsonable):
 
                         # Update influence
                         for influence_power in self.powers.values():
-                            if word[-1] in influence_power.influence:
-                                influence_power.influence.remove(word[-1])
-                        power.influence.append(word[-1])
+                            if word[-1][:3] in influence_power.influence:
+                                influence_power.influence.remove(word[-1][:3])
+                        power.influence.append(word[-1][:3])
 
                     if unit not in self.ordered_units[power.name]:
                         self.ordered_units[power.name] += [unit]


### PR DESCRIPTION
Retreating to a coast was influencing the coast itself (eg, `SPA/SC`).
This could end up causing `SPA/SC` to be influenced by one power and `SPA` to be influenced by an other power (eg, when a fleet from the second power moves to `SPA/NC`).
This situation causes #113 / [SHADE-AI/diplomacy#6](https://github.com/SHADE-AI/diplomacy/issues/6) when visualizing the game.

I fixed the retreat influence to be similar to a move influence (eg., influence `SPA`).